### PR TITLE
Activate Manually GPS by Opening Location Settings Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Features
 --------
 
 - PhoneGap plugin used to detect if the GPS if enabled or disabled on the device
+- PhoneGap plugin used to open Location Settings and activate them manually
 - Compatible with Cordova 2.2.0 to 3.1.0 (older and newer versions not tested)
 - Tested (and working) on Android 4.4 KitKat (Nexus 5)
+
 
 Setup
 -----

--- a/assets/www/js/gpsDetectionPlugin.js
+++ b/assets/www/js/gpsDetectionPlugin.js
@@ -7,6 +7,10 @@ cordova.define('cordova/plugin/gpsDetectionPlugin', function(require, exports, m
     	exec(successCallback, failureCallback, 'GpsDetectionPlugin', 'gpsDetection', []);
     };
     
+    gpsDetect.prototype.switchToLocationSettings = function() {
+        exec(null,null,'GpsDetectionPlugin','gpsActivation',[]);
+    };
+    
     var gpsDetect = new gpsDetect();
     module.exports = gpsDetect;
 });

--- a/src/com/butterflyeffect/plugins/GPSDetectionPlugin.java
+++ b/src/com/butterflyeffect/plugins/GPSDetectionPlugin.java
@@ -17,6 +17,7 @@ public class GPSDetectionPlugin extends CordovaPlugin {
     	PluginResult result = null;
         boolean gpsEnabled = false;
         String GPSDetectionAction = "gpsDetection";
+        String GPSActivation = "gpsActivation";
         
         if (action.equals(GPSDetectionAction)) {
         	android.content.ContentResolver contentResolver = cordova.getActivity().getApplicationContext().getContentResolver();
@@ -24,7 +25,13 @@ public class GPSDetectionPlugin extends CordovaPlugin {
         	result = new PluginResult(Status.OK, gpsEnabled);
         }
         else {
-            result = new PluginResult(Status.INVALID_ACTION);
+           if(action.equals(GPSActivation)) {
+                Intent settingsIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+                cordova.getActivity().startActivity(settingsIntent);
+            }
+            else {
+                result = new PluginResult(Status.INVALID_ACTION);
+            }
         }
         
         callbackContext.sendPluginResult(result);


### PR DESCRIPTION
Just a few lines, that let the plugin opening the Locations Settings Activity, for manually enable the GPS.
